### PR TITLE
fix formdata in node environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whop-sdk-ts",
-  "version": "0.0.4-canary.3",
+  "version": "0.0.4-canary.4",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,5 +42,8 @@
   "browser": "./browser/index.mjs",
   "optionalDependencies": {
     "undici": "5.14.0"
+  },
+  "dependencies": {
+    "form-data": "4.0.0"
   }
 }

--- a/packages/core/request/node/core/request.ts
+++ b/packages/core/request/node/core/request.ts
@@ -8,6 +8,7 @@ import { CancelablePromise } from "../../core/CancelablePromise";
 import type { OnCancel } from "../../core/CancelablePromise";
 import type { OpenAPIConfig } from "../../core/OpenAPI";
 import type { Response as UndiciResponse } from "undici";
+import FormData from "form-data";
 
 type FullResponse = Response | UndiciResponse;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,7 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@types/glob': ^8.0.0
       concurrently: 7.6.0
+      form-data: 4.0.0
       fs-extra: ^10.1.0
       glob: ^8.0.3
       openapi-typescript-codegen: ^0.23.0
@@ -56,6 +57,8 @@ importers:
       tsconfig: workspace:^0.0.0
       typescript: 4.9.3
       undici: 5.14.0
+    dependencies:
+      form-data: 4.0.0
     optionalDependencies:
       undici: 5.14.0
     devDependencies:
@@ -2010,7 +2013,6 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /axe-core/4.5.2:
     resolution: {integrity: sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==}
@@ -2272,7 +2274,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2438,7 +2439,6 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /depd/2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3269,7 +3269,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /format-util/1.0.5:
     resolution: {integrity: sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==}
@@ -4169,14 +4168,12 @@ packages:
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types/2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}


### PR DESCRIPTION
FormData is not available natively in node so for the node runtime the `form-data` npm module is used