### PR TITLE
chore: rename fields and add jsdoc for attachments

### DIFF
--- a/packages/api/src/attachments/upload.ts
+++ b/packages/api/src/attachments/upload.ts
@@ -100,6 +100,18 @@ interface UploadFileOptions {
 }
 
 /**
+ * Response returned by `UploadAttachment`.
+ */
+export interface UploadAttachmentResponse {
+	/** The direct upload ID - use this to attach the attachment to a resource */
+	directUploadId: string;
+	/** The record type the attachment was attached to */
+	record: AttachableRecords;
+	/** The attachment */
+	attachment: AttachmentFragment;
+}
+
+/**
  * Uploads a file.
  * @param input - The input to upload.
  * @param opts - The options to upload the file.
@@ -112,14 +124,7 @@ export async function uploadAttachment(
 	>,
 	input: UploadFileInput,
 	{ onProgress, signal }: UploadFileOptions = {},
-): Promise<{
-	/** The direct upload ID - use this to attach the attachment to a resource */
-	directUploadId: string;
-	/** The record type the attachment was attached to */
-	record: AttachableRecords;
-	/** The attachment */
-	attachment: AttachmentFragment;
-}> {
+): Promise<UploadAttachmentResponse> {
 	// prepare the file
 	const preparedAttachment =
 		"record" in input && "file" in input

--- a/packages/api/src/attachments/upload.ts
+++ b/packages/api/src/attachments/upload.ts
@@ -113,8 +113,11 @@ export async function uploadAttachment(
 	input: UploadFileInput,
 	{ onProgress, signal }: UploadFileOptions = {},
 ): Promise<{
-	id: string;
+	/** The direct upload ID - use this to attach the attachment to a resource */
+	directUploadId: string;
+	/** The record type the attachment was attached to */
 	record: AttachableRecords;
+	/** The attachment */
 	attachment: AttachmentFragment;
 }> {
 	// prepare the file
@@ -156,7 +159,7 @@ export async function uploadAttachment(
 	}
 
 	return {
-		id: preparedAttachment.id,
+		directUploadId: preparedAttachment.id,
 		record: preparedAttachment.record,
 		attachment,
 	};

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,3 +1,4 @@
+export type { UploadAttachmentResponse } from "@/attachments/upload";
 export type * from "@/codegen/generated-api";
 export * as proto from "@/codegen/proto";
 export { WhopClientSdk, type WhopClientSdkOptions } from "@/sdk.client";


### PR DESCRIPTION
### ✨ Upload Attachment Helper

| Change                 | Detail                                                                                                                        |
|------------------------|--------------------------------------------------------------------------------------------------------------------------------|
| **Clearer response type** | Added JSDoc annotations to `AttachmentUploadResponse` so IDEs surface the field descriptions and types automatically. |
| **Property renamed**   | `AttachmentUploadResponse.id` → **`AttachmentUploadResponse.directUploadId`**. The new name conveys intent (the *Direct Upload* identifier) and eliminates ambiguity with generic `id` fields. |

```ts
/**
 * Response returned by `UploadAttachment`.
 */
export interface AttachmentUploadResponse {
  /** The direct upload ID - use this to attach the attachment to a resource */
  directUploadId: string;
  /** The record type the attachment was attached to */
  record: AttachableRecords;
  /** The attachment */
  attachment: AttachmentFragment;
}
