### PR TITLE
chore: add `repository` field to all published packages

### DIFF
--- a/.changeset/fuzzy-waves-see.md
+++ b/.changeset/fuzzy-waves-see.md
@@ -1,0 +1,8 @@
+---
+"@whop/checkout": patch
+"@whop/iframe": patch
+"@whop/react": patch
+"@whop/api": patch
+---
+
+add repository field to package.json

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,15 @@
 {
 	"name": "@whop/api",
 	"version": "0.0.21",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/whopio/whop-sdk-ts",
+		"directory": "packages/api"
+	},
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.mjs",
+	"types": "./dist/index.d.ts",
+	"files": ["dist"],
 	"exports": {
 		".": {
 			"node": {
@@ -33,10 +42,6 @@
 			}
 		}
 	},
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
-	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",
 		"build:proto": "bash ./scripts/generate-protos.sh",

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "@whop/checkout",
 	"version": "0.0.21",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/whopio/whop-sdk-ts",
+		"directory": "packages/checkout"
+	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",

--- a/packages/iframe/package.json
+++ b/packages/iframe/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "@whop/iframe",
 	"version": "0.0.1",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/whopio/whop-sdk-ts",
+		"directory": "packages/iframe"
+	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "@whop/react",
 	"version": "0.0.1",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/whopio/whop-sdk-ts",
+		"directory": "packages/react"
+	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds the `repository` field to all published packages so npm can link back to this repo