### PR TITLE
feat: support `center` checkout event

### DIFF
--- a/.changeset/cool-donuts-carry.md
+++ b/.changeset/cool-donuts-carry.md
@@ -1,0 +1,5 @@
+---
+"@whop/checkout": patch
+---
+
+support `center` event and handle event listener cleanup

--- a/.changeset/new-crabs-flash.md
+++ b/.changeset/new-crabs-flash.md
@@ -1,0 +1,8 @@
+---
+"@whop/checkout": patch
+"@whop/api": patch
+"@whop/iframe": patch
+"@whop/react": patch
+---
+
+update .npmignore to include build configs

--- a/packages/api/.npmignore
+++ b/packages/api/.npmignore
@@ -1,7 +1,9 @@
 graphql
 node_modules
 codegen.ts
+.swcrc
 tsconfig.json
+tsup.config.ts
 turbo.json
 src
 .gitignore

--- a/packages/checkout/.npmignore
+++ b/packages/checkout/.npmignore
@@ -1,7 +1,9 @@
 graphql
 node_modules
 codegen.ts
+.swcrc
 tsconfig.json
+tsup.config.ts
 turbo.json
 src
 .gitignore
@@ -14,3 +16,4 @@ src
 scripts
 
 dist/index.html
+public

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -10,7 +10,7 @@ To embed checkout, you need to add the following script tag into the `<head>` of
 <script
   async
   defer
-  src="https://cdn.jsdelivr.net/npm/@whop/checkout@0.0.21-canary.8/dist/loader.js"
+  src="https://cdn.jsdelivr.net/npm/@whop/checkout/dist/loader.js"
 ></script>
 ```
 

--- a/packages/checkout/public/index.html
+++ b/packages/checkout/public/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">
-		<script src="http://localhost:3000/loader.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/@whop/checkout/dist/loader.js"></script>
 		<title>Whop embedded checkout</title>
 		<style>
 			div {
@@ -15,7 +15,6 @@
 		</style>
 	</head>
 	<body style="display: flex; height: fit-content; width: 100%">
-		<div style="flex: 1; height: fit-content; overflow: hidden; max-width: 50%;" data-whop-checkout-theme="light" data-whop-checkout-origin="http://localhost:8004" data-whop-checkout-plan-id="plan_ziYsgX0C9r4rG"></div>
-		<div style="flex: 1; height: fit-content; overflow: hidden; max-width: 50%;" data-whop-checkout-theme="light" data-whop-checkout-origin="http://localhost:8004" data-whop-checkout-plan-id="plan_ziYsgX0C9r4rG"></div>
+		<div style="flex: 1; height: fit-content; overflow: hidden; max-width: 50%;" data-whop-checkout-theme="light" data-whop-checkout-plan-id="plan_QnbKDNAbfcXr8"></div>
 	</body>
 </html>

--- a/packages/checkout/src/loader.ts
+++ b/packages/checkout/src/loader.ts
@@ -15,6 +15,7 @@ if (typeof window !== "undefined" && loaderScriptSrc) {
 		return {
 			injected: true,
 			listening: false,
+			frames: new Map(),
 		};
 	})();
 }

--- a/packages/checkout/src/types.d.ts
+++ b/packages/checkout/src/types.d.ts
@@ -3,6 +3,7 @@ declare global {
 		wco?: {
 			injected: true;
 			listening: boolean;
+			frames: Map<HTMLIFrameElement, () => void>;
 		};
 	}
 }

--- a/packages/iframe/.npmignore
+++ b/packages/iframe/.npmignore
@@ -1,7 +1,9 @@
 graphql
 node_modules
 codegen.ts
+.swcrc
 tsconfig.json
+tsup.config.ts
 turbo.json
 src
 .gitignore

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -1,7 +1,9 @@
 graphql
 node_modules
 codegen.ts
+.swcrc
 tsconfig.json
+tsup.config.ts
 turbo.json
 src
 .gitignore


### PR DESCRIPTION
## Why

The embedded checkout frame is sending `center` events when an overlay like the otp modal is shown. This is to ensure that any of these overlays is properly centered and in view of the user when presented.

## What changed

- Added handling for the `center` events emitted by the checkout frame
- Added missing cleanup handling for event handlers when checkout frames get unmounted
