### PR TITLE
fix(react): fix esm build output

### DIFF
--- a/.changeset/sad-glasses-move.md
+++ b/.changeset/sad-glasses-move.md
@@ -1,0 +1,5 @@
+---
+"@whop/react": patch
+---
+
+fix esm build output

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,7 @@
 		"build": "pnpm run clean && concurrently \"pnpm run build:swc\" \"pnpm run build:tsc\"",
 		"build:swc": "concurrently \"pnpm run build:swc:esm\" \"pnpm run build:swc:cjs\"",
 		"build:swc:cjs": "swc src -d dist --strip-leading-paths --out-file-extension cjs -C module.type=commonjs",
-		"build:swc:esm": "swc src -d dist --strip-leading-paths --out-file-extension mjs -C module.type=es6",
+		"build:swc:esm": "swc src -d dist --strip-leading-paths --out-file-extension mjs -C module.type=es6 && node scripts/fix-esm-output.mjs",
 		"build:tsc": "tsc --emitDeclarationOnly",
 		"clean": "rm -rf dist",
 		"dev": "concurrently \"pnpm run dev:swc\" \"pnpm run dev:tsc\"",

--- a/packages/react/scripts/fix-esm-output.mjs
+++ b/packages/react/scripts/fix-esm-output.mjs
@@ -1,0 +1,102 @@
+// @ts-check
+
+import { readdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { parseFile, print } from "@swc/core";
+
+/**
+ * @param {string} dir
+ */
+async function fixDirectory(dir) {
+	const filesAndDirs = await readdir(dir);
+	for (const fileOrDir of filesAndDirs) {
+		const fileOrDirPath = join(dir, fileOrDir);
+		const stats = await stat(fileOrDirPath);
+		if (stats.isDirectory()) {
+			await fixDirectory(fileOrDirPath);
+		} else if (stats.isFile() && fileOrDirPath.endsWith(".mjs")) {
+			await fixFile(fileOrDirPath);
+		}
+	}
+}
+
+/**
+ * @param {string} filePath
+ */
+async function fixFile(filePath) {
+	const ast = await parseFile(filePath, {
+		syntax: "ecmascript",
+	});
+
+	ast.body = await Promise.all(
+		ast.body.map(async (item) => {
+			switch (item.type) {
+				case "ImportDeclaration": {
+					const importedPath = item.source.value;
+					if (!importedPath.startsWith(".")) return item;
+					const newPath = await fixSinglePath(filePath, importedPath);
+					item.source.value = newPath;
+					item.source.raw = `"${newPath}"`;
+					return item;
+				}
+				case "ExportNamedDeclaration": {
+					if (!item.source?.value) return item;
+					const exportedPath = item.source.value;
+					if (!exportedPath.startsWith(".")) return item;
+					const newPath = await fixSinglePath(filePath, exportedPath);
+					item.source.value = newPath;
+					item.source.raw = `"${newPath}"`;
+					return item;
+				}
+				case "ExportAllDeclaration": {
+					if (!item.source?.value) return item;
+					const exportedPath = item.source.value;
+					if (!exportedPath.startsWith(".")) return item;
+					const newPath = await fixSinglePath(filePath, exportedPath);
+					item.source.value = newPath;
+					item.source.raw = `"${newPath}"`;
+					return item;
+				}
+			}
+			return item;
+		}),
+	);
+
+	const { code } = await print(ast);
+	await writeFile(filePath, code);
+}
+
+/**
+ * @param {string} path
+ */
+async function exists(path) {
+	try {
+		const stats = await stat(path);
+		return stats.isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * @param {string} importer
+ * @param {string} importedPath
+ */
+async function fixSinglePath(importer, importedPath) {
+	const resolvedPath = join(dirname(importer), importedPath);
+	const baseFile = `${resolvedPath}.mjs`;
+	const baseIndex = `${resolvedPath}/index.mjs`;
+
+	if (await exists(baseFile)) {
+		return `${importedPath}.mjs`;
+	}
+
+	if (await exists(baseIndex)) {
+		return `${importedPath}/index.mjs`;
+	}
+
+	throw new Error(`Could not find ${importedPath} in ${importer}`);
+}
+
+await fixDirectory(join(process.cwd(), "dist"));

--- a/packages/react/scripts/tsconfig.json
+++ b/packages/react/scripts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"lib": ["ESNext", "dom", "DOM.Iterable"],
+		"types": ["node"],
+		"module": "ESNext",
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"esModuleInterop": true,
+		"moduleResolution": "bundler",
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"strictNullChecks": true,
+		"verbatimModuleSyntax": true,
+		"outDir": "./dist"
+	},
+	"exclude": ["node_modules", "dist"],
+	"include": ["**/*.mjs"]
+}


### PR DESCRIPTION
The esm build output of the react package was broken and imports could not be properly resolved. This PR adds a fix-esm-output.mjs script that runs after the esm build to fix the output files.