### PR TITLE
chore: update renovate to widen peer deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,12 @@
 		},
 		{
 			"matchManagers": ["npm"],
+			"matchDepTypes": ["peerDependencies", "optionalDependencies"],
+			"rangeStrategy": "widen"
+		},
+		{
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["dependencies", "devDependencies"],
 			"rangeStrategy": "pin"
 		}
 	],


### PR DESCRIPTION
Updates renovate config to widen peer dependencies. Pinning peers is not what we want