### PR TITLE
feat: add `skipRedirect` option to checkout and react

### DIFF
--- a/.changeset/tame-pears-tap.md
+++ b/.changeset/tame-pears-tap.md
@@ -1,0 +1,6 @@
+---
+"@whop/checkout": patch
+"@whop/react": patch
+---
+
+add `skipRedirect` option to checkout and react packages

--- a/apps/docs/features/checkout-embed.mdx
+++ b/apps/docs/features/checkout-embed.mdx
@@ -51,6 +51,12 @@ This can be used to attach metadata to a checkout by first creating a session th
 
 Defaults to `false`
 
+#### **`skipRedirect`**
+
+**Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
+
+Defaults to `false`
+
 #### **`fallback`**
 
 **Optional** - The fallback content to show while the checkout is loading.
@@ -139,6 +145,16 @@ Defaults to `false`
 
 ```md
 <div data-whop-checkout-hide-price="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
+```
+
+#### **`data-whop-checkout-skip-redirect`**
+
+**Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
+
+Defaults to `false`
+
+```md
+<div data-whop-checkout-skip-redirect="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
 ```
 
 ### Full example

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -56,6 +56,27 @@ This can be used to attach metadata to a checkout by first creating a session th
 <div data-whop-checkout-session-id="ch_XXXXXXXXX" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
 ```
 
+### **`data-whop-checkout-hide-price`**
+
+**Optional** - Set to `true` to hide the price in the embedded checkout form.
+
+Defaults to `false`
+
+```md
+<div data-whop-checkout-hide-price="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
+```
+
+### **`data-whop-checkout-skip-redirect`**
+
+**Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
+
+Defaults to `false`
+
+```md
+<div data-whop-checkout-skip-redirect="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
+```
+
+
 ## Full example
 
 ```md

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -39,6 +39,7 @@ function mount(node: HTMLElement) {
 		node.dataset.whopCheckoutSession,
 		node.dataset.whopCheckoutOrigin,
 		node.dataset.whopCheckoutHidePrice === "true",
+		node.dataset.whopCheckoutSkipRedirect === "true",
 	);
 
 	const iframe = document.createElement("iframe");

--- a/packages/checkout/src/util.ts
+++ b/packages/checkout/src/util.ts
@@ -47,6 +47,7 @@ export function getEmbeddedCheckoutIframeUrl(
 	sessionId?: string,
 	origin?: string,
 	hidePrice?: boolean,
+	skipRedirect?: boolean,
 ) {
 	const iframeUrl = new URL(
 		`/embedded/checkout/${planId}/`,
@@ -63,6 +64,9 @@ export function getEmbeddedCheckoutIframeUrl(
 	}
 	if (hidePrice) {
 		iframeUrl.searchParams.set("hide_price", "true");
+	}
+	if (skipRedirect) {
+		iframeUrl.searchParams.set("skip_redirect", "true");
 	}
 	return iframeUrl.toString();
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -151,6 +151,12 @@ export default function Home() {
 			 */
 			hidePrice={false}
 			/**
+			* **Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
+			*
+			* @default false
+			*/
+			skipRedirect={false}
+			/**
 			 * **Optional** - The fallback content to show while the checkout is loading.
 			 */
 			fallback={<>loading...</>}

--- a/packages/react/src/checkout/embed.tsx
+++ b/packages/react/src/checkout/embed.tsx
@@ -41,6 +41,12 @@ export interface WhopCheckoutEmbedProps {
 	 * @default false
 	 */
 	hidePrice?: boolean;
+	/**
+	 * **Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
+	 *
+	 * @default false
+	 */
+	skipRedirect?: boolean;
 }
 
 function WhopCheckoutEmbedInner({
@@ -48,6 +54,7 @@ function WhopCheckoutEmbedInner({
 	theme,
 	sessionId,
 	hidePrice = false,
+	skipRedirect = false,
 }: WhopCheckoutEmbedProps): React.ReactNode {
 	const { current: iframeUrl } = useLazyRef(() =>
 		getEmbeddedCheckoutIframeUrl(
@@ -56,6 +63,7 @@ function WhopCheckoutEmbedInner({
 			sessionId,
 			undefined,
 			hidePrice,
+			skipRedirect,
 		),
 	);
 
@@ -83,7 +91,14 @@ function WhopCheckoutEmbedInner({
 		);
 	}, []);
 
-	useWarnOnIframeUrlChange(iframeUrl, planId, theme, sessionId, hidePrice);
+	useWarnOnIframeUrlChange(
+		iframeUrl,
+		planId,
+		theme,
+		sessionId,
+		hidePrice,
+		skipRedirect,
+	);
 
 	return (
 		<iframe

--- a/packages/react/src/checkout/util.ts
+++ b/packages/react/src/checkout/util.ts
@@ -10,6 +10,7 @@ export function useWarnOnIframeUrlChange(
 	theme?: "light" | "dark" | "system",
 	sessionId?: string,
 	hidePrice?: boolean,
+	skipRedirect?: boolean,
 ) {
 	const updatedIframeUrl = useMemo(
 		() =>
@@ -19,8 +20,9 @@ export function useWarnOnIframeUrlChange(
 				sessionId,
 				undefined,
 				hidePrice,
+				skipRedirect,
 			),
-		[planId, theme, sessionId, hidePrice],
+		[planId, theme, sessionId, hidePrice, skipRedirect],
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
This PR adds the SDK implementation of the `skipRedirect` feature for embedded checkout:
- Update checkout utils to handle the param when creating the embed url
- Update checkout embed loader to read from the `data-whop-checkout-skip-redirect` attribute
- Update react package to add `skipRedirect` prop to the `WhopCheckoutEmbed` component