### PR TITLE
fix: add `Decimal` to gql scalar defs

### DIFF
--- a/.changeset/tame-gifts-joke.md
+++ b/.changeset/tame-gifts-joke.md
@@ -1,0 +1,5 @@
+---
+"@whop/api": patch
+---
+
+add `Decimal` to gql scalar defs

--- a/packages/api/codegen.ts
+++ b/packages/api/codegen.ts
@@ -56,6 +56,7 @@ const graphqlCodegenConfig = {
 		UrlString: "string",
 		StringFloat: "string | number",
 		Requirements: "Record<string, unknown>",
+		Decimal: "string",
 	},
 };
 


### PR DESCRIPTION
The builds for the api package are failing because the `Decimal` scalar is missing from the codegen scalar type mapping