### PR TITLE
feat(checkout+react): add embed styling api

### DIFF
--- a/.changeset/giant-emus-hammer.md
+++ b/.changeset/giant-emus-hammer.md
@@ -1,0 +1,6 @@
+---
+"@whop/checkout": patch
+"@whop/react": patch
+---
+
+add styling api to embedded checkout

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -1,6 +1,7 @@
 import {
 	EMBEDDED_CHECKOUT_IFRAME_ALLOW_STRING,
 	EMBEDDED_CHECKOUT_IFRAME_SANDBOX_LIST,
+	type WhopEmbeddedCheckoutStyleOptions,
 	getEmbeddedCheckoutIframeUrl,
 	onWhopCheckoutMessage,
 } from "./util";
@@ -60,6 +61,25 @@ function getUtmFromCurrentUrl() {
 	}, {});
 }
 
+const WHOP_CHECKOUT_STYLE_PREFIX = "data-whop-checkout-style-";
+
+function getStylesFromNode(node: HTMLElement) {
+	const styles: Record<string, Record<string, string | number>> = {};
+	for (const attr of node.attributes) {
+		if (attr.name.startsWith(WHOP_CHECKOUT_STYLE_PREFIX)) {
+			const key = attr.name.slice(WHOP_CHECKOUT_STYLE_PREFIX.length);
+			const value = attr.value;
+			const [componentName, styleAttribute] = key.split("-");
+			if (componentName && styleAttribute) {
+				styles[componentName] ??= {};
+				styles[componentName][styleAttribute] = value;
+			}
+		}
+	}
+
+	return styles as WhopEmbeddedCheckoutStyleOptions;
+}
+
 function mount(node: HTMLElement) {
 	if (node.dataset.whopCheckoutMounted) {
 		return;
@@ -81,6 +101,7 @@ function mount(node: HTMLElement) {
 		node.dataset.whopCheckoutSkipUtm === "true"
 			? undefined
 			: getUtmFromCurrentUrl(),
+		getStylesFromNode(node),
 	);
 
 	const iframe = document.createElement("iframe");

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -69,8 +69,13 @@ function getStylesFromNode(node: HTMLElement) {
 		if (attr.name.startsWith(WHOP_CHECKOUT_STYLE_PREFIX)) {
 			const key = attr.name.slice(WHOP_CHECKOUT_STYLE_PREFIX.length);
 			const value = attr.value;
-			const [componentName, styleAttribute] = key.split("-");
-			if (componentName && styleAttribute) {
+			const [componentName, ...styleAttributeParts] = key.split("-");
+			if (componentName && styleAttributeParts.length > 0) {
+				const styleAttribute = styleAttributeParts.reduce((acc, part, idx) => {
+					if (idx === 0) return part;
+					const [firstChar, ...rest] = acc;
+					return `${acc}${firstChar.toUpperCase()}${rest.join("")}`;
+				}, "");
 				styles[componentName] ??= {};
 				styles[componentName][styleAttribute] = value;
 			}

--- a/packages/checkout/src/util.ts
+++ b/packages/checkout/src/util.ts
@@ -48,6 +48,14 @@ export function onWhopCheckoutMessage(
 	};
 }
 
+export interface WhopEmbeddedCheckoutStyleOptions {
+	container?: {
+		paddingTop?: number | string;
+		paddingBottom?: number | string;
+		paddingY?: number | string;
+	};
+}
+
 export function getEmbeddedCheckoutIframeUrl(
 	planId: string,
 	theme?: "light" | "dark" | "system",
@@ -56,6 +64,7 @@ export function getEmbeddedCheckoutIframeUrl(
 	hidePrice?: boolean,
 	skipRedirect?: boolean,
 	utm?: Record<string, string | string[]>,
+	styles?: WhopEmbeddedCheckoutStyleOptions,
 ) {
 	const iframeUrl = new URL(
 		`/embedded/checkout/${planId}/`,
@@ -87,6 +96,18 @@ export function getEmbeddedCheckoutIframeUrl(
 				}
 			} else {
 				iframeUrl.searchParams.set(key, value);
+			}
+		}
+	}
+	if (styles) {
+		for (const [key, value] of Object.entries(styles) as [
+			string,
+			Record<string, string | number> | undefined,
+		][]) {
+			if (value) {
+				for (const [key1, value1] of Object.entries(value)) {
+					iframeUrl.searchParams.set(`style.${key}.${key1}`, value1.toString());
+				}
 			}
 		}
 	}

--- a/packages/checkout/src/util.ts
+++ b/packages/checkout/src/util.ts
@@ -100,13 +100,18 @@ export function getEmbeddedCheckoutIframeUrl(
 		}
 	}
 	if (styles) {
-		for (const [key, value] of Object.entries(styles) as [
+		for (const [component, componentStyles] of Object.entries(styles) as [
 			string,
 			Record<string, string | number> | undefined,
 		][]) {
-			if (value) {
-				for (const [key1, value1] of Object.entries(value)) {
-					iframeUrl.searchParams.set(`style.${key}.${key1}`, value1.toString());
+			if (componentStyles) {
+				for (const [styleAttribute, styleValue] of Object.entries(
+					componentStyles,
+				)) {
+					iframeUrl.searchParams.set(
+						`style.${component}.${styleAttribute}`,
+						styleValue.toString(),
+					);
 				}
 			}
 		}

--- a/packages/react/src/checkout/embed.tsx
+++ b/packages/react/src/checkout/embed.tsx
@@ -2,6 +2,7 @@
 
 import {
 	EMBEDDED_CHECKOUT_IFRAME_ALLOW_STRING,
+	type WhopEmbeddedCheckoutStyleOptions,
 	getEmbeddedCheckoutIframeUrl,
 	onWhopCheckoutMessage,
 } from "@whop/checkout/util";
@@ -62,6 +63,10 @@ export interface WhopCheckoutEmbedProps {
 	 * **Note** - The keys must start with `utm_`
 	 */
 	utm?: Record<string, string | string[]>;
+	/**
+	 * **Optional** - The styles to apply to the checkout embed.
+	 */
+	styles?: WhopEmbeddedCheckoutStyleOptions;
 }
 
 function WhopCheckoutEmbedInner({
@@ -72,6 +77,7 @@ function WhopCheckoutEmbedInner({
 	skipRedirect = false,
 	onComplete,
 	utm,
+	styles,
 }: WhopCheckoutEmbedProps): React.ReactNode {
 	const { current: iframeUrl } = useLazyRef(() =>
 		getEmbeddedCheckoutIframeUrl(
@@ -82,6 +88,7 @@ function WhopCheckoutEmbedInner({
 			hidePrice,
 			skipRedirect || !!onComplete,
 			utm,
+			styles,
 		),
 	);
 

--- a/packages/react/src/checkout/util.ts
+++ b/packages/react/src/checkout/util.ts
@@ -1,5 +1,6 @@
 import {
 	EMBEDDED_CHECKOUT_IFRAME_SANDBOX_LIST,
+	type WhopEmbeddedCheckoutStyleOptions,
 	getEmbeddedCheckoutIframeUrl,
 } from "@whop/checkout/util";
 import { useEffect, useMemo } from "react";
@@ -12,6 +13,7 @@ export function useWarnOnIframeUrlChange(
 	hidePrice?: boolean,
 	skipRedirect?: boolean,
 	utm?: Record<string, string | string[]>,
+	styles?: WhopEmbeddedCheckoutStyleOptions,
 ) {
 	const updatedIframeUrl = useMemo(
 		() =>
@@ -23,8 +25,9 @@ export function useWarnOnIframeUrlChange(
 				hidePrice,
 				skipRedirect,
 				utm,
+				styles,
 			),
-		[planId, theme, sessionId, hidePrice, skipRedirect, utm],
+		[planId, theme, sessionId, hidePrice, skipRedirect, utm, styles],
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
Allows styling the embed checkout, not documenting publicly because there are not a lot of props that can be styled and i want to confirm stability + add a way to update the styles while checkout is open.