### PR TITLE
fix(checkout): malformed forwarded style attribute

### DIFF
--- a/.changeset/tired-ways-thank.md
+++ b/.changeset/tired-ways-thank.md
@@ -1,0 +1,5 @@
+---
+"@whop/checkout": patch
+---
+
+fix malformed style attribute

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -73,7 +73,7 @@ function getStylesFromNode(node: HTMLElement) {
 			if (componentName && styleAttributeParts.length > 0) {
 				const styleAttribute = styleAttributeParts.reduce((acc, part, idx) => {
 					if (idx === 0) return part;
-					const [firstChar, ...rest] = acc;
+					const [firstChar, ...rest] = part;
 					return `${acc}${firstChar.toUpperCase()}${rest.join("")}`;
 				}, "");
 				styles[componentName] ??= {};


### PR DESCRIPTION
The reducer that constructed the forwarded style tag for the query param style api was broken and produced incorrect values causing integrations to not be able to use the style ap.