### PR TITLE
fix(framer): re-exporting does not work well

### DIFF
--- a/.changeset/clever-jars-ring.md
+++ b/.changeset/clever-jars-ring.md
@@ -1,0 +1,5 @@
+---
+"@whop/framer": patch
+---
+
+update setup and guides for framer embedded checkout

--- a/apps/docs/features/checkout-embed.mdx
+++ b/apps/docs/features/checkout-embed.mdx
@@ -129,7 +129,21 @@ Navigate to the **Assets** tab in your framer project, click the **+** button ne
 Paste the following code into the editor:
 
 ```tsx
-export { default } from "@whop/framer/checkout";
+import {
+  WhopFramerCheckoutEmbed,
+  propertyControls,
+} from "@whop/framer/checkout";
+import { addPropertyControls } from "framer";
+
+/**
+ * @framerSupportedLayoutWidth auto
+ * @framerSupportedLayoutHeight auto
+ */
+export default function WhopCheckoutEmbed(props) {
+  return <WhopFramerCheckoutEmbed {...props} />;
+}
+
+addPropertyControls(WhopCheckoutEmbed, propertyControls);
 ```
 
 You can now use the checkout embed component in your project and configure it through the framer interface.

--- a/packages/framer/README.md
+++ b/packages/framer/README.md
@@ -15,7 +15,21 @@ Navigate to the **Assets** tab in your framer project, click the **+** button ne
 Paste the following code into the editor:
 
 ```tsx
-export { default } from "@whop/framer/checkout";
+import {
+  WhopFramerCheckoutEmbed,
+  propertyControls,
+} from "@whop/framer/checkout";
+import { addPropertyControls } from "framer";
+
+/**
+ * @framerSupportedLayoutWidth auto
+ * @framerSupportedLayoutHeight auto
+ */
+export default function WhopCheckoutEmbed(props) {
+  return <WhopFramerCheckoutEmbed {...props} />;
+}
+
+addPropertyControls(WhopCheckoutEmbed, propertyControls);
 ```
 
 You can now use the checkout embed component in your project and configure it through the framer interface.

--- a/packages/framer/src/checkout.tsx
+++ b/packages/framer/src/checkout.tsx
@@ -2,11 +2,11 @@ import {
 	type WhopEmbeddedCheckoutStyleOptions,
 	WhopCheckoutEmbed as WhopReactCheckoutEmbed,
 } from "@whop/react/checkout";
-import { ControlType, addPropertyControls } from "framer";
+import { ControlType, type PropertyControls } from "framer";
 import React, { useMemo } from "react";
 import type { ReactNode } from "react";
 
-export default function WhopFramerCheckoutEmbed(props: {
+export interface WhopFramerCheckoutEmbedProps {
 	planId: string;
 	theme?: "light" | "dark" | "system" | "auto";
 	sessionId?: string;
@@ -17,7 +17,9 @@ export default function WhopFramerCheckoutEmbed(props: {
 	containerPaddingTop?: number;
 	containerPaddingBottom?: number;
 	containerPaddingY?: number;
-}) {
+}
+
+export function WhopFramerCheckoutEmbed(props: WhopFramerCheckoutEmbedProps) {
 	const styles: WhopEmbeddedCheckoutStyleOptions = useMemo(() => {
 		return {
 			container: {
@@ -44,59 +46,62 @@ export default function WhopFramerCheckoutEmbed(props: {
 	);
 }
 
-addPropertyControls(WhopFramerCheckoutEmbed, {
-	planId: {
-		type: ControlType.String,
-		title: "Plan ID",
-		description: "The plan ID you want to checkout",
-	},
-	theme: {
-		type: ControlType.Enum,
-		displaySegmentedControl: true,
-		defaultValue: "auto",
-		segmentedControlDirection: "vertical",
-		options: ["light", "dark", "system", "auto"],
-		optionTitles: ["Light", "Dark", "System", "Auto"],
-		description: "The theme you want to use for the checkout",
-	},
-	sessionId: {
-		type: ControlType.String,
-		title: "Session ID",
-		description:
-			"The session ID you want to use for the checkout (i.e. 'ch_xxxxxxx'",
-	},
-	hidePrice: {
-		type: ControlType.Boolean,
-		title: "Hide Price",
-		defaultValue: false,
-		description: "Set to true to hide the price in the embedded checkout form",
-	},
-	skipRedirect: {
-		type: ControlType.Boolean,
-		title: "Skip Redirect",
-		defaultValue: false,
-		description:
-			"Set to true to skip the final redirect and keep the top frame loaded",
-	},
-	onComplete: {
-		type: ControlType.EventHandler,
-		description:
-			"A callback function that will be called when the checkout is complete",
-	},
-	fallback: {
-		type: ControlType.ComponentInstance,
-		description: "The fallback content to show while the checkout is loading.",
-	},
-	containerPaddingTop: {
-		type: ControlType.Number,
-		description: "The top padding of the checkout embed container",
-	},
-	containerPaddingBottom: {
-		type: ControlType.Number,
-		description: "The bottom padding of the checkout embed container",
-	},
-	containerPaddingY: {
-		type: ControlType.Number,
-		description: "The vertical padding of the checkout embed container",
-	},
-});
+export const propertyControls: PropertyControls<WhopFramerCheckoutEmbedProps> =
+	{
+		planId: {
+			type: ControlType.String,
+			title: "Plan ID",
+			description: "The plan ID you want to checkout",
+		},
+		theme: {
+			type: ControlType.Enum,
+			displaySegmentedControl: true,
+			defaultValue: "auto",
+			segmentedControlDirection: "vertical",
+			options: ["light", "dark", "system", "auto"],
+			optionTitles: ["Light", "Dark", "System", "Auto"],
+			description: "The theme you want to use for the checkout",
+		},
+		sessionId: {
+			type: ControlType.String,
+			title: "Session ID",
+			description:
+				"The session ID you want to use for the checkout (i.e. 'ch_xxxxxxx'",
+		},
+		hidePrice: {
+			type: ControlType.Boolean,
+			title: "Hide Price",
+			defaultValue: false,
+			description:
+				"Set to true to hide the price in the embedded checkout form",
+		},
+		skipRedirect: {
+			type: ControlType.Boolean,
+			title: "Skip Redirect",
+			defaultValue: false,
+			description:
+				"Set to true to skip the final redirect and keep the top frame loaded",
+		},
+		onComplete: {
+			type: ControlType.EventHandler,
+			description:
+				"A callback function that will be called when the checkout is complete",
+		},
+		fallback: {
+			type: ControlType.ComponentInstance,
+			description:
+				"The fallback content to show while the checkout is loading.",
+		},
+		containerPaddingTop: {
+			type: ControlType.Number,
+			description: "The top padding of the checkout embed container",
+		},
+		containerPaddingBottom: {
+			type: ControlType.Number,
+			description: "The bottom padding of the checkout embed container",
+		},
+		containerPaddingY: {
+			type: ControlType.Number,
+			description: "The vertical padding of the checkout embed container",
+		},
+	};

--- a/packages/framer/src/index.ts
+++ b/packages/framer/src/index.ts
@@ -1,1 +1,2 @@
-export { default as WhopFramerCheckoutEmbed } from "./checkout";
+export * from "./checkout";
+export type * from "./checkout";


### PR DESCRIPTION
When testing this package on framer i found that the `export { default } from "..."` pattern does not work well. This PR switches how the package is set up by introducing a little more boilerplate code. The setup on the framer side is now the following:
```tsx
import {
  WhopFramerCheckoutEmbed,
  propertyControls,
} from "@whop/framer/checkout";
import { addPropertyControls } from "framer";

/**
 * @framerSupportedLayoutWidth auto
 * @framerSupportedLayoutHeight auto
 */
export default function WhopCheckoutEmbed(props) {
  return <WhopFramerCheckoutEmbed {...props} />;
}

addPropertyControls(WhopCheckoutEmbed, propertyControls);
```