### PR TITLE
deps(frosted-ui): update to v77

### DIFF
--- a/.changeset/sweet-rules-eat.md
+++ b/.changeset/sweet-rules-eat.md
@@ -1,0 +1,5 @@
+---
+"@whop/react": minor
+---
+
+Update frosted-ui to v77

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,7 +83,7 @@
 		"@whop/api": "workspace:^",
 		"@whop/checkout": "workspace:^",
 		"@whop/iframe": "workspace:^",
-		"frosted-ui": "0.0.1-canary.74",
+		"frosted-ui": "0.0.1-canary.77",
 		"use-sync-external-store": "^1.5.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,8 +469,8 @@ importers:
         specifier: workspace:^
         version: link:../iframe
       frosted-ui:
-        specifier: 0.0.1-canary.74
-        version: 0.0.1-canary.74(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.0.1-canary.77
+        version: 0.0.1-canary.77(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       use-sync-external-store:
         specifier: ^1.5.0
         version: 1.5.0(react@19.1.0)
@@ -5483,8 +5483,8 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
-  frosted-ui@0.0.1-canary.74:
-    resolution: {integrity: sha512-VCaFnITJktJ8U+v2OuOZ5wt9R4lVa6yYcknDOt3+1LshSn8+LlfgyNmt777Ck4qEobPrVFTNmtLqRFrSCHm/CQ==}
+  frosted-ui@0.0.1-canary.77:
+    resolution: {integrity: sha512-L3z/0H7Jh9qN9wxIZFTjNiToxkBJ/1lZl/JkEOi9UYxsAIfSnclePEJR6jOXCxyVQmFBLhcWjydjmarEFYSImg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -14396,7 +14396,7 @@ snapshots:
 
   fresh@0.5.2: {}
 
-  frosted-ui@0.0.1-canary.74(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  frosted-ui@0.0.1-canary.77(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@frosted-ui/colors': 0.0.1-canary.61
       '@internationalized/date': 3.8.2


### PR DESCRIPTION
Updates frosted-ui to v77 to include latest tweaks from our Figma UI kit polish sprint