### PR TITLE
fix(checkout): onComplete callback not firing

### DIFF
--- a/.changeset/honest-cougars-flash.md
+++ b/.changeset/honest-cougars-flash.md
@@ -1,0 +1,5 @@
+---
+"@whop/checkout": patch
+---
+
+fix onComplete callback

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -6,7 +6,7 @@ import {
 	onWhopCheckoutMessage,
 } from "./util";
 
-function listen(iframe: HTMLIFrameElement) {
+function listen(iframe: HTMLIFrameElement, node: HTMLElement) {
 	window.wco?.frames.set(
 		iframe,
 		onWhopCheckoutMessage(iframe, function handleWhopCheckoutMessage(message) {
@@ -20,7 +20,7 @@ function listen(iframe: HTMLIFrameElement) {
 					break;
 				}
 				case "complete": {
-					const callbackTarget = iframe.dataset.whopCheckoutOnComplete;
+					const callbackTarget = node.dataset.whopCheckoutOnComplete;
 					if (callbackTarget) {
 						const callback = (
 							window as unknown as {
@@ -128,7 +128,7 @@ function mount(node: HTMLElement) {
 	node.appendChild(iframe);
 
 	// listen for iframe events
-	listen(iframe);
+	listen(iframe, node);
 }
 
 if (typeof window !== "undefined" && window.wco && !window.wco.listening) {


### PR DESCRIPTION
The complete callback was mistakenly reading the data tag for the callback target from the iframes dataset instead of the containers dataset. this PR fixes this behavior