### PR TITLE
Add courses mutations for creating, updating and deleting lessons and chapters

### DIFF
--- a/.changeset/cyan-ants-lick.md
+++ b/.changeset/cyan-ants-lick.md
@@ -1,0 +1,5 @@
+---
+"@whop/api": patch
+---
+
+Add courses mutations for creating, updating and deleting lessons and chapters

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -388,10 +388,18 @@
 				{
 					"group": "Courses",
 					"pages": [
+						"sdk/api/courses/create-chapter",
+						"sdk/api/courses/create-lesson",
+						"sdk/api/courses/delete-chapter",
+						"sdk/api/courses/delete-lesson",
 						"sdk/api/courses/get-course",
 						"sdk/api/courses/get-lesson",
 						"sdk/api/courses/get-user-lesson-interactions",
-						"sdk/api/courses/mark-lesson-as-completed"
+						"sdk/api/courses/mark-lesson-as-completed",
+						"sdk/api/courses/update-chapter-order",
+						"sdk/api/courses/update-chapter",
+						"sdk/api/courses/update-lesson-order",
+						"sdk/api/courses/update-lesson"
 					]
 				},
 				{

--- a/apps/docs/sdk/api/courses/create-chapter.mdx
+++ b/apps/docs/sdk/api/courses/create-chapter.mdx
@@ -1,0 +1,89 @@
+---
+title: Create Chapter
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.createChapter({
+	// The ID of the course to create the chapter in
+	courseId: "xxxxxxxxxxx" /* Required! */,
+
+	// The title of the chapter
+	title: "some string",
+});
+
+```
+
+Example output:
+
+```typescript
+const response = {
+	// The ID of the chapter. Looks like chap_XXX
+	id: "xxxxxxxxxxx",
+
+	// The title of the chapter
+	title: "some string",
+
+	// The order of the chapter within its course
+	order: 10,
+
+	// The lessons in this chapter
+	lessons: [
+		{
+			// The ID of the lesson
+			id: "xxxxxxxxxxx",
+
+			// The type of the lesson (text, video, pdf, multi, quiz, knowledge_check)
+			lessonType:
+				"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+			// The title of the lesson
+			title: "some string",
+
+			// The order of the lesson within its chapter
+			order: 10,
+
+			// Number of days from course start until the lesson is unlocked
+			daysFromCourseStartUntilUnlock: 10,
+
+			// The content of the lesson
+			content: "some string",
+
+			// The associated Mux asset for video lessons
+			muxAsset: {
+				// The ID of the Mux asset
+				id: "xxxxxxxxxxx",
+
+				// The Mux-provided ID of the asset
+				muxAssetId: "some string",
+
+				// The public playback ID of the Mux asset
+				playbackId: "some string",
+
+				// The signed playback ID of the Mux asset
+				signedPlaybackId: "some string",
+
+				// The signed thumbnail playback token of the Mux asset
+				signedThumbnailPlaybackToken: "some string",
+
+				// The signed video playback token of the Mux asset
+				signedVideoPlaybackToken: "some string",
+
+				// The signed storyboard playback token of the Mux asset
+				signedStoryboardPlaybackToken: "some string",
+
+				// The duration of the video in seconds
+				durationSeconds: 10,
+
+				// The status of the Mux asset
+				status: "created" /* Valid values: created | ready | uploading */,
+
+				// The time at which the video finished uploading
+				finishedUploadingAt: 1716931200,
+			},
+		},
+	],
+};
+
+```

--- a/apps/docs/sdk/api/courses/create-lesson.mdx
+++ b/apps/docs/sdk/api/courses/create-lesson.mdx
@@ -1,0 +1,281 @@
+---
+title: Create Lesson
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.createLesson({
+	// The ID of the chapter to create the lesson in
+	chapterId: "xxxxxxxxxxx" /* Required! */,
+
+	// The content of the lesson
+	content: "some string",
+
+	// Days from course start until unlock
+	daysFromCourseStartUntilUnlock: 10,
+
+	// The type of the lesson
+	lessonType:
+		"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */ /* Required! */,
+
+	// The title of the lesson
+	title: "some string",
+});
+
+```
+
+Example output:
+
+```typescript
+const response = {
+	// The ID of the lesson
+	id: "xxxxxxxxxxx",
+
+	// The type of the lesson (text, video, pdf, multi, quiz, knowledge_check)
+	lessonType:
+		"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+	// The title of the lesson
+	title: "some string",
+
+	// The order of the lesson within its chapter
+	order: 10,
+
+	// The content of the lesson
+	content: "some string",
+
+	// Number of days from course start until the lesson is unlocked
+	daysFromCourseStartUntilUnlock: 10,
+
+	// The associated Mux asset for video lessons
+	muxAsset: {
+		// The ID of the Mux asset
+		id: "xxxxxxxxxxx",
+
+		// The Mux-provided ID of the asset
+		muxAssetId: "some string",
+
+		// The public playback ID of the Mux asset
+		playbackId: "some string",
+
+		// The signed playback ID of the Mux asset
+		signedPlaybackId: "some string",
+
+		// The signed thumbnail playback token of the Mux asset
+		signedThumbnailPlaybackToken: "some string",
+
+		// The signed video playback token of the Mux asset
+		signedVideoPlaybackToken: "some string",
+
+		// The signed storyboard playback token of the Mux asset
+		signedStoryboardPlaybackToken: "some string",
+
+		// The duration of the video in seconds
+		durationSeconds: 10,
+
+		// The status of the Mux asset
+		status: "created" /* Valid values: created | ready | uploading */,
+
+		// The time at which the video finished uploading
+		finishedUploadingAt: 1716931200,
+	},
+
+	// Assessment questions for quiz/knowledge check lessons
+	assessmentQuestions: [
+		{
+			// The ID of the assessment question
+			id: "xxxxxxxxxxx",
+
+			// The correct answer for the question
+			correctAnswer: "some string",
+
+			// Optional image attachment for the question
+			image: {
+				// The ID of the attachment
+				id: "xxxxxxxxxxx",
+
+				// A signed ID of the attachment to directly query the attachment
+				signedId: "xxxxxxxxxxx",
+
+				// Whether the attachment has been analyzed
+				analyzed: true,
+
+				// The size of the file in bytes
+				byteSizeV2: "9999999",
+
+				// The name of the file
+				filename: "some string",
+
+				// The attachment's content type (e.g., image/jpg, video/mp4)
+				contentType: "some string",
+
+				// The source of the attachment
+				source: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The blurhash of the image
+				blurhash: "some string",
+
+				// The height of the video
+				height: 10,
+
+				// The width of the video
+				width: 10,
+
+				// The aspect ratio of the video
+				aspectRatio: 10,
+
+				// The preview of the video
+				preview: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The duration of the audio in seconds
+				duration: 10,
+
+				// The URL of the waveform for the audio
+				waveformUrl: "some string",
+			},
+
+			// The answer options for multiple choice/select questions
+			options: [
+				{
+					// The ID of the assessment question option
+					id: "xxxxxxxxxxx",
+
+					// Whether this option is a correct answer
+					isCorrect: true,
+
+					// The text of the answer option
+					optionText: "some string",
+
+					// The order of this option within the question
+					order: 10,
+				},
+			],
+
+			// The order of the question within its lesson
+			order: 10,
+
+			// The text of the question
+			questionText: "some string",
+
+			// The type of the question
+			questionType:
+				"multiple_choice" /* Valid values: multiple_choice | multiple_select | short_answer | true_false */,
+		},
+	],
+
+	// The attached files in this lesson
+	attachments: {
+		// A list of nodes.
+		nodes: [
+			{
+				// The ID of the attachment
+				id: "xxxxxxxxxxx",
+
+				// A signed ID of the attachment to directly query the attachment
+				signedId: "xxxxxxxxxxx",
+
+				// Whether the attachment has been analyzed
+				analyzed: true,
+
+				// The size of the file in bytes
+				byteSizeV2: "9999999",
+
+				// The name of the file
+				filename: "some string",
+
+				// The attachment's content type (e.g., image/jpg, video/mp4)
+				contentType: "some string",
+
+				// The source of the attachment
+				source: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The blurhash of the image
+				blurhash: "some string",
+
+				// The height of the video
+				height: 10,
+
+				// The width of the video
+				width: 10,
+
+				// The aspect ratio of the video
+				aspectRatio: 10,
+
+				// The preview of the video
+				preview: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The duration of the audio in seconds
+				duration: 10,
+
+				// The URL of the waveform for the audio
+				waveformUrl: "some string",
+			},
+		],
+	},
+
+	// The main PDF file for this lesson
+	mainPdf: {
+		// The ID of the attachment
+		id: "xxxxxxxxxxx",
+
+		// A signed ID of the attachment to directly query the attachment
+		signedId: "xxxxxxxxxxx",
+
+		// Whether the attachment has been analyzed
+		analyzed: true,
+
+		// The size of the file in bytes
+		byteSizeV2: "9999999",
+
+		// The name of the file
+		filename: "some string",
+
+		// The attachment's content type (e.g., image/jpg, video/mp4)
+		contentType: "some string",
+
+		// The source of the attachment
+		source: {
+			// The URL to access the attachment
+			url: "some string",
+		},
+
+		// The blurhash of the image
+		blurhash: "some string",
+
+		// The height of the video
+		height: 10,
+
+		// The width of the video
+		width: 10,
+
+		// The aspect ratio of the video
+		aspectRatio: 10,
+
+		// The preview of the video
+		preview: {
+			// The URL to access the attachment
+			url: "some string",
+		},
+
+		// The duration of the audio in seconds
+		duration: 10,
+
+		// The URL of the waveform for the audio
+		waveformUrl: "some string",
+	},
+};
+
+```

--- a/apps/docs/sdk/api/courses/delete-chapter.mdx
+++ b/apps/docs/sdk/api/courses/delete-chapter.mdx
@@ -1,0 +1,20 @@
+---
+title: Delete Chapter
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.deleteChapter({
+	// The ID of the chapter to delete
+	id: "xxxxxxxxxxx" /* Required! */,
+});
+
+```
+
+Example output:
+
+```typescript
+const response = true;
+
+```

--- a/apps/docs/sdk/api/courses/delete-lesson.mdx
+++ b/apps/docs/sdk/api/courses/delete-lesson.mdx
@@ -1,0 +1,20 @@
+---
+title: Delete Lesson
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.deleteLesson({
+	// The ID of the lesson to delete
+	id: "xxxxxxxxxxx" /* Required! */,
+});
+
+```
+
+Example output:
+
+```typescript
+const response = true;
+
+```

--- a/apps/docs/sdk/api/courses/get-user-lesson-interactions.mdx
+++ b/apps/docs/sdk/api/courses/get-user-lesson-interactions.mdx
@@ -20,6 +20,9 @@ const response = {
 	// The chapters in this course
 	chapters: [
 		{
+			// The ID of the chapter. Looks like chap_XXX
+			id: "xxxxxxxxxxx",
+
 			// The lessons in this chapter
 			lessons: [
 				{
@@ -33,6 +36,9 @@ const response = {
 
 						// Whether the lesson has been completed by the user
 						completed: true,
+
+						// When the interaction was created
+						createdAt: 1716931200,
 					},
 				},
 			],

--- a/apps/docs/sdk/api/courses/update-chapter-order.mdx
+++ b/apps/docs/sdk/api/courses/update-chapter-order.mdx
@@ -1,0 +1,89 @@
+---
+title: Update Chapter Order
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.updateChapterOrder({
+	// The ID of the chapter to place this chapter below
+	belowChapterId: "xxxxxxxxxxx",
+
+	// The ID of the chapter to reorder
+	chapterId: "xxxxxxxxxxx" /* Required! */,
+});
+
+```
+
+Example output:
+
+```typescript
+const response = {
+	// The ID of the chapter. Looks like chap_XXX
+	id: "xxxxxxxxxxx",
+
+	// The title of the chapter
+	title: "some string",
+
+	// The order of the chapter within its course
+	order: 10,
+
+	// The lessons in this chapter
+	lessons: [
+		{
+			// The ID of the lesson
+			id: "xxxxxxxxxxx",
+
+			// The type of the lesson (text, video, pdf, multi, quiz, knowledge_check)
+			lessonType:
+				"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+			// The title of the lesson
+			title: "some string",
+
+			// The order of the lesson within its chapter
+			order: 10,
+
+			// Number of days from course start until the lesson is unlocked
+			daysFromCourseStartUntilUnlock: 10,
+
+			// The content of the lesson
+			content: "some string",
+
+			// The associated Mux asset for video lessons
+			muxAsset: {
+				// The ID of the Mux asset
+				id: "xxxxxxxxxxx",
+
+				// The Mux-provided ID of the asset
+				muxAssetId: "some string",
+
+				// The public playback ID of the Mux asset
+				playbackId: "some string",
+
+				// The signed playback ID of the Mux asset
+				signedPlaybackId: "some string",
+
+				// The signed thumbnail playback token of the Mux asset
+				signedThumbnailPlaybackToken: "some string",
+
+				// The signed video playback token of the Mux asset
+				signedVideoPlaybackToken: "some string",
+
+				// The signed storyboard playback token of the Mux asset
+				signedStoryboardPlaybackToken: "some string",
+
+				// The duration of the video in seconds
+				durationSeconds: 10,
+
+				// The status of the Mux asset
+				status: "created" /* Valid values: created | ready | uploading */,
+
+				// The time at which the video finished uploading
+				finishedUploadingAt: 1716931200,
+			},
+		},
+	],
+};
+
+```

--- a/apps/docs/sdk/api/courses/update-chapter.mdx
+++ b/apps/docs/sdk/api/courses/update-chapter.mdx
@@ -1,0 +1,89 @@
+---
+title: Update Chapter
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.updateChapter({
+	// The ID of the chapter to update
+	id: "xxxxxxxxxxx" /* Required! */,
+
+	// The title of the chapter
+	title: "some string" /* Required! */,
+});
+
+```
+
+Example output:
+
+```typescript
+const response = {
+	// The ID of the chapter. Looks like chap_XXX
+	id: "xxxxxxxxxxx",
+
+	// The title of the chapter
+	title: "some string",
+
+	// The order of the chapter within its course
+	order: 10,
+
+	// The lessons in this chapter
+	lessons: [
+		{
+			// The ID of the lesson
+			id: "xxxxxxxxxxx",
+
+			// The type of the lesson (text, video, pdf, multi, quiz, knowledge_check)
+			lessonType:
+				"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+			// The title of the lesson
+			title: "some string",
+
+			// The order of the lesson within its chapter
+			order: 10,
+
+			// Number of days from course start until the lesson is unlocked
+			daysFromCourseStartUntilUnlock: 10,
+
+			// The content of the lesson
+			content: "some string",
+
+			// The associated Mux asset for video lessons
+			muxAsset: {
+				// The ID of the Mux asset
+				id: "xxxxxxxxxxx",
+
+				// The Mux-provided ID of the asset
+				muxAssetId: "some string",
+
+				// The public playback ID of the Mux asset
+				playbackId: "some string",
+
+				// The signed playback ID of the Mux asset
+				signedPlaybackId: "some string",
+
+				// The signed thumbnail playback token of the Mux asset
+				signedThumbnailPlaybackToken: "some string",
+
+				// The signed video playback token of the Mux asset
+				signedVideoPlaybackToken: "some string",
+
+				// The signed storyboard playback token of the Mux asset
+				signedStoryboardPlaybackToken: "some string",
+
+				// The duration of the video in seconds
+				durationSeconds: 10,
+
+				// The status of the Mux asset
+				status: "created" /* Valid values: created | ready | uploading */,
+
+				// The time at which the video finished uploading
+				finishedUploadingAt: 1716931200,
+			},
+		},
+	],
+};
+
+```

--- a/apps/docs/sdk/api/courses/update-lesson-order.mdx
+++ b/apps/docs/sdk/api/courses/update-lesson-order.mdx
@@ -1,0 +1,274 @@
+---
+title: Update Lesson Order
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.updateLessonOrder({
+	// The ID of the lesson to place this lesson below
+	belowLessonId: "xxxxxxxxxxx",
+
+	// The ID of the chapter to move the lesson to
+	chapterId: "xxxxxxxxxxx" /* Required! */,
+
+	// The ID of the lesson to reorder
+	lessonId: "xxxxxxxxxxx" /* Required! */,
+});
+
+```
+
+Example output:
+
+```typescript
+const response = {
+	// The ID of the lesson
+	id: "xxxxxxxxxxx",
+
+	// The type of the lesson (text, video, pdf, multi, quiz, knowledge_check)
+	lessonType:
+		"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+	// The title of the lesson
+	title: "some string",
+
+	// The order of the lesson within its chapter
+	order: 10,
+
+	// The content of the lesson
+	content: "some string",
+
+	// Number of days from course start until the lesson is unlocked
+	daysFromCourseStartUntilUnlock: 10,
+
+	// The associated Mux asset for video lessons
+	muxAsset: {
+		// The ID of the Mux asset
+		id: "xxxxxxxxxxx",
+
+		// The Mux-provided ID of the asset
+		muxAssetId: "some string",
+
+		// The public playback ID of the Mux asset
+		playbackId: "some string",
+
+		// The signed playback ID of the Mux asset
+		signedPlaybackId: "some string",
+
+		// The signed thumbnail playback token of the Mux asset
+		signedThumbnailPlaybackToken: "some string",
+
+		// The signed video playback token of the Mux asset
+		signedVideoPlaybackToken: "some string",
+
+		// The signed storyboard playback token of the Mux asset
+		signedStoryboardPlaybackToken: "some string",
+
+		// The duration of the video in seconds
+		durationSeconds: 10,
+
+		// The status of the Mux asset
+		status: "created" /* Valid values: created | ready | uploading */,
+
+		// The time at which the video finished uploading
+		finishedUploadingAt: 1716931200,
+	},
+
+	// Assessment questions for quiz/knowledge check lessons
+	assessmentQuestions: [
+		{
+			// The ID of the assessment question
+			id: "xxxxxxxxxxx",
+
+			// The correct answer for the question
+			correctAnswer: "some string",
+
+			// Optional image attachment for the question
+			image: {
+				// The ID of the attachment
+				id: "xxxxxxxxxxx",
+
+				// A signed ID of the attachment to directly query the attachment
+				signedId: "xxxxxxxxxxx",
+
+				// Whether the attachment has been analyzed
+				analyzed: true,
+
+				// The size of the file in bytes
+				byteSizeV2: "9999999",
+
+				// The name of the file
+				filename: "some string",
+
+				// The attachment's content type (e.g., image/jpg, video/mp4)
+				contentType: "some string",
+
+				// The source of the attachment
+				source: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The blurhash of the image
+				blurhash: "some string",
+
+				// The height of the video
+				height: 10,
+
+				// The width of the video
+				width: 10,
+
+				// The aspect ratio of the video
+				aspectRatio: 10,
+
+				// The preview of the video
+				preview: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The duration of the audio in seconds
+				duration: 10,
+
+				// The URL of the waveform for the audio
+				waveformUrl: "some string",
+			},
+
+			// The answer options for multiple choice/select questions
+			options: [
+				{
+					// The ID of the assessment question option
+					id: "xxxxxxxxxxx",
+
+					// Whether this option is a correct answer
+					isCorrect: true,
+
+					// The text of the answer option
+					optionText: "some string",
+
+					// The order of this option within the question
+					order: 10,
+				},
+			],
+
+			// The order of the question within its lesson
+			order: 10,
+
+			// The text of the question
+			questionText: "some string",
+
+			// The type of the question
+			questionType:
+				"multiple_choice" /* Valid values: multiple_choice | multiple_select | short_answer | true_false */,
+		},
+	],
+
+	// The attached files in this lesson
+	attachments: {
+		// A list of nodes.
+		nodes: [
+			{
+				// The ID of the attachment
+				id: "xxxxxxxxxxx",
+
+				// A signed ID of the attachment to directly query the attachment
+				signedId: "xxxxxxxxxxx",
+
+				// Whether the attachment has been analyzed
+				analyzed: true,
+
+				// The size of the file in bytes
+				byteSizeV2: "9999999",
+
+				// The name of the file
+				filename: "some string",
+
+				// The attachment's content type (e.g., image/jpg, video/mp4)
+				contentType: "some string",
+
+				// The source of the attachment
+				source: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The blurhash of the image
+				blurhash: "some string",
+
+				// The height of the video
+				height: 10,
+
+				// The width of the video
+				width: 10,
+
+				// The aspect ratio of the video
+				aspectRatio: 10,
+
+				// The preview of the video
+				preview: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The duration of the audio in seconds
+				duration: 10,
+
+				// The URL of the waveform for the audio
+				waveformUrl: "some string",
+			},
+		],
+	},
+
+	// The main PDF file for this lesson
+	mainPdf: {
+		// The ID of the attachment
+		id: "xxxxxxxxxxx",
+
+		// A signed ID of the attachment to directly query the attachment
+		signedId: "xxxxxxxxxxx",
+
+		// Whether the attachment has been analyzed
+		analyzed: true,
+
+		// The size of the file in bytes
+		byteSizeV2: "9999999",
+
+		// The name of the file
+		filename: "some string",
+
+		// The attachment's content type (e.g., image/jpg, video/mp4)
+		contentType: "some string",
+
+		// The source of the attachment
+		source: {
+			// The URL to access the attachment
+			url: "some string",
+		},
+
+		// The blurhash of the image
+		blurhash: "some string",
+
+		// The height of the video
+		height: 10,
+
+		// The width of the video
+		width: 10,
+
+		// The aspect ratio of the video
+		aspectRatio: 10,
+
+		// The preview of the video
+		preview: {
+			// The URL to access the attachment
+			url: "some string",
+		},
+
+		// The duration of the audio in seconds
+		duration: 10,
+
+		// The URL of the waveform for the audio
+		waveformUrl: "some string",
+	},
+};
+
+```

--- a/apps/docs/sdk/api/courses/update-lesson.mdx
+++ b/apps/docs/sdk/api/courses/update-lesson.mdx
@@ -1,0 +1,281 @@
+---
+title: Update Lesson
+---
+
+```typescript
+import { whopSdk } from "@/lib/whop-sdk";
+
+const result = await whopSdk.courses.updateLesson({
+	// The content of the lesson
+	content: "some string",
+
+	// Days from course start until unlock
+	daysFromCourseStartUntilUnlock: 10,
+
+	// The ID of the lesson to update
+	id: "xxxxxxxxxxx" /* Required! */,
+
+	// The type of the lesson
+	lessonType:
+		"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+	// The title of the lesson
+	title: "some string",
+});
+
+```
+
+Example output:
+
+```typescript
+const response = {
+	// The ID of the lesson
+	id: "xxxxxxxxxxx",
+
+	// The type of the lesson (text, video, pdf, multi, quiz, knowledge_check)
+	lessonType:
+		"knowledge_check" /* Valid values: knowledge_check | multi | pdf | quiz | text | video */,
+
+	// The title of the lesson
+	title: "some string",
+
+	// The order of the lesson within its chapter
+	order: 10,
+
+	// The content of the lesson
+	content: "some string",
+
+	// Number of days from course start until the lesson is unlocked
+	daysFromCourseStartUntilUnlock: 10,
+
+	// The associated Mux asset for video lessons
+	muxAsset: {
+		// The ID of the Mux asset
+		id: "xxxxxxxxxxx",
+
+		// The Mux-provided ID of the asset
+		muxAssetId: "some string",
+
+		// The public playback ID of the Mux asset
+		playbackId: "some string",
+
+		// The signed playback ID of the Mux asset
+		signedPlaybackId: "some string",
+
+		// The signed thumbnail playback token of the Mux asset
+		signedThumbnailPlaybackToken: "some string",
+
+		// The signed video playback token of the Mux asset
+		signedVideoPlaybackToken: "some string",
+
+		// The signed storyboard playback token of the Mux asset
+		signedStoryboardPlaybackToken: "some string",
+
+		// The duration of the video in seconds
+		durationSeconds: 10,
+
+		// The status of the Mux asset
+		status: "created" /* Valid values: created | ready | uploading */,
+
+		// The time at which the video finished uploading
+		finishedUploadingAt: 1716931200,
+	},
+
+	// Assessment questions for quiz/knowledge check lessons
+	assessmentQuestions: [
+		{
+			// The ID of the assessment question
+			id: "xxxxxxxxxxx",
+
+			// The correct answer for the question
+			correctAnswer: "some string",
+
+			// Optional image attachment for the question
+			image: {
+				// The ID of the attachment
+				id: "xxxxxxxxxxx",
+
+				// A signed ID of the attachment to directly query the attachment
+				signedId: "xxxxxxxxxxx",
+
+				// Whether the attachment has been analyzed
+				analyzed: true,
+
+				// The size of the file in bytes
+				byteSizeV2: "9999999",
+
+				// The name of the file
+				filename: "some string",
+
+				// The attachment's content type (e.g., image/jpg, video/mp4)
+				contentType: "some string",
+
+				// The source of the attachment
+				source: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The blurhash of the image
+				blurhash: "some string",
+
+				// The height of the video
+				height: 10,
+
+				// The width of the video
+				width: 10,
+
+				// The aspect ratio of the video
+				aspectRatio: 10,
+
+				// The preview of the video
+				preview: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The duration of the audio in seconds
+				duration: 10,
+
+				// The URL of the waveform for the audio
+				waveformUrl: "some string",
+			},
+
+			// The answer options for multiple choice/select questions
+			options: [
+				{
+					// The ID of the assessment question option
+					id: "xxxxxxxxxxx",
+
+					// Whether this option is a correct answer
+					isCorrect: true,
+
+					// The text of the answer option
+					optionText: "some string",
+
+					// The order of this option within the question
+					order: 10,
+				},
+			],
+
+			// The order of the question within its lesson
+			order: 10,
+
+			// The text of the question
+			questionText: "some string",
+
+			// The type of the question
+			questionType:
+				"multiple_choice" /* Valid values: multiple_choice | multiple_select | short_answer | true_false */,
+		},
+	],
+
+	// The attached files in this lesson
+	attachments: {
+		// A list of nodes.
+		nodes: [
+			{
+				// The ID of the attachment
+				id: "xxxxxxxxxxx",
+
+				// A signed ID of the attachment to directly query the attachment
+				signedId: "xxxxxxxxxxx",
+
+				// Whether the attachment has been analyzed
+				analyzed: true,
+
+				// The size of the file in bytes
+				byteSizeV2: "9999999",
+
+				// The name of the file
+				filename: "some string",
+
+				// The attachment's content type (e.g., image/jpg, video/mp4)
+				contentType: "some string",
+
+				// The source of the attachment
+				source: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The blurhash of the image
+				blurhash: "some string",
+
+				// The height of the video
+				height: 10,
+
+				// The width of the video
+				width: 10,
+
+				// The aspect ratio of the video
+				aspectRatio: 10,
+
+				// The preview of the video
+				preview: {
+					// The URL to access the attachment
+					url: "some string",
+				},
+
+				// The duration of the audio in seconds
+				duration: 10,
+
+				// The URL of the waveform for the audio
+				waveformUrl: "some string",
+			},
+		],
+	},
+
+	// The main PDF file for this lesson
+	mainPdf: {
+		// The ID of the attachment
+		id: "xxxxxxxxxxx",
+
+		// A signed ID of the attachment to directly query the attachment
+		signedId: "xxxxxxxxxxx",
+
+		// Whether the attachment has been analyzed
+		analyzed: true,
+
+		// The size of the file in bytes
+		byteSizeV2: "9999999",
+
+		// The name of the file
+		filename: "some string",
+
+		// The attachment's content type (e.g., image/jpg, video/mp4)
+		contentType: "some string",
+
+		// The source of the attachment
+		source: {
+			// The URL to access the attachment
+			url: "some string",
+		},
+
+		// The blurhash of the image
+		blurhash: "some string",
+
+		// The height of the video
+		height: 10,
+
+		// The width of the video
+		width: 10,
+
+		// The aspect ratio of the video
+		aspectRatio: 10,
+
+		// The preview of the video
+		preview: {
+			// The URL to access the attachment
+			url: "some string",
+		},
+
+		// The duration of the audio in seconds
+		duration: 10,
+
+		// The URL of the waveform for the audio
+		waveformUrl: "some string",
+	},
+};
+
+```

--- a/packages/api/graphql/operations/courses/create-chapter.shared.graphql
+++ b/packages/api/graphql/operations/courses/create-chapter.shared.graphql
@@ -1,0 +1,5 @@
+mutation createChapter($input: CreateChapterInput!) {
+	createChapter(input: $input) {
+		...BasicCourseChapter
+	}
+}

--- a/packages/api/graphql/operations/courses/create-lesson.shared.graphql
+++ b/packages/api/graphql/operations/courses/create-lesson.shared.graphql
@@ -1,0 +1,5 @@
+mutation createLesson($input: CreateLessonInput!) {
+	createLesson(input: $input) {
+		...FullCourseLesson
+	}
+}

--- a/packages/api/graphql/operations/courses/delete-chapter.shared.graphql
+++ b/packages/api/graphql/operations/courses/delete-chapter.shared.graphql
@@ -1,5 +1,3 @@
 mutation deleteChapter($input: DeleteChapterInput!) {
-	deleteChapter(input: $input) {
-		...BasicCourseChapter
-	}
+	deleteChapter(input: $input)
 }

--- a/packages/api/graphql/operations/courses/delete-chapter.shared.graphql
+++ b/packages/api/graphql/operations/courses/delete-chapter.shared.graphql
@@ -1,0 +1,5 @@
+mutation deleteChapter($input: DeleteChapterInput!) {
+	deleteChapter(input: $input) {
+		...BasicCourseChapter
+	}
+}

--- a/packages/api/graphql/operations/courses/delete-course.shared.graphql
+++ b/packages/api/graphql/operations/courses/delete-course.shared.graphql
@@ -1,0 +1,5 @@
+mutation deleteCourse($input: DeleteCourseInput!) {
+	deleteCourse(input: $input) {
+		...BasicCourse
+	}
+}

--- a/packages/api/graphql/operations/courses/delete-course.shared.graphql
+++ b/packages/api/graphql/operations/courses/delete-course.shared.graphql
@@ -1,5 +1,0 @@
-mutation deleteCourse($input: DeleteCourseInput!) {
-	deleteCourse(input: $input) {
-		...BasicCourse
-	}
-}

--- a/packages/api/graphql/operations/courses/delete-lesson.shared.graphql
+++ b/packages/api/graphql/operations/courses/delete-lesson.shared.graphql
@@ -1,0 +1,3 @@
+mutation deleteLesson($input: DeleteLessonInput!) {
+	deleteLesson(input: $input)
+}

--- a/packages/api/graphql/operations/courses/get-user-lesson-interactions.shared.graphql
+++ b/packages/api/graphql/operations/courses/get-user-lesson-interactions.shared.graphql
@@ -1,11 +1,13 @@
 query getUserLessonInteractions($experienceId: ID!) {
 	course(experienceId: $experienceId) {
 		chapters {
+			id
 			lessons {
 				id
 				lessonInteraction {
 					id
 					completed
+					createdAt
 				}
 			}
 		}

--- a/packages/api/graphql/operations/courses/update-chapter-order.shared.graphql
+++ b/packages/api/graphql/operations/courses/update-chapter-order.shared.graphql
@@ -1,0 +1,5 @@
+mutation updateChapterOrder($input: UpdateChapterOrderInput!) {
+	updateChapterOrder(input: $input) {
+		...BasicCourseChapter
+	}
+}

--- a/packages/api/graphql/operations/courses/update-chapter.shared.graphql
+++ b/packages/api/graphql/operations/courses/update-chapter.shared.graphql
@@ -1,0 +1,5 @@
+mutation updateChapter($input: UpdateChapterInput!) {
+	updateChapter(input: $input) {
+		...BasicCourseChapter
+	}
+}

--- a/packages/api/graphql/operations/courses/update-lesson-order.shared.graphql
+++ b/packages/api/graphql/operations/courses/update-lesson-order.shared.graphql
@@ -1,0 +1,5 @@
+mutation updateLessonOrder($input: UpdateLessonOrderInput!) {
+	updateLessonOrder(input: $input) {
+		...FullCourseLesson
+	}
+}

--- a/packages/api/graphql/operations/courses/update-lesson.shared.graphql
+++ b/packages/api/graphql/operations/courses/update-lesson.shared.graphql
@@ -1,0 +1,5 @@
+mutation updateLesson($input: UpdateLessonInput!) {
+	updateLesson(input: $input) {
+		...FullCourseLesson
+	}
+}


### PR DESCRIPTION
new mutations:

- createLesson
- createChapter
- updateLesson
- updateChapter
- deleteLesson
- deleteChapter
- updateLessonOrder
- updateChapterOrder

also made a minor change to the getUserLessonInteractions query. added the ids of chapters, and the createdAt of the lesson interaction.