### PR TITLE
Change courses.getUserLessonInteractions query to use course id instead of experience id

### DIFF
--- a/.changeset/true-signs-bow.md
+++ b/.changeset/true-signs-bow.md
@@ -1,0 +1,5 @@
+---
+"@whop/api": patch
+---
+
+Change courses.getUserLessonInteractions query to use course id instead of experience id

--- a/apps/docs/sdk/api/courses/create-chapter.mdx
+++ b/apps/docs/sdk/api/courses/create-chapter.mdx
@@ -7,7 +7,7 @@ import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.createChapter({
 	// The ID of the course to create the chapter in
-	courseId: "xxxxxxxxxxx" /* Required! */,
+	courseId: "cors_XXXXXXXX" /* Required! */,
 
 	// The title of the chapter
 	title: "some string",

--- a/apps/docs/sdk/api/courses/create-lesson.mdx
+++ b/apps/docs/sdk/api/courses/create-lesson.mdx
@@ -7,7 +7,7 @@ import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.createLesson({
 	// The ID of the chapter to create the lesson in
-	chapterId: "xxxxxxxxxxx" /* Required! */,
+	chapterId: "chap_XXXXXXXX" /* Required! */,
 
 	// The content of the lesson
 	content: "some string",

--- a/apps/docs/sdk/api/courses/get-course.mdx
+++ b/apps/docs/sdk/api/courses/get-course.mdx
@@ -7,7 +7,9 @@ description: A course from a courses app experience
 import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.getCourse({
-	// The ID of the experience that has the course.
+	// The ID of the experience that has the course. (this is deprecated, use the
+	// id argument instead. passing this in will return the first course in the
+	// experience for backwards compatibility)
 	experienceId: "exp_XXXXXXXX" /* Required! */,
 });
 

--- a/apps/docs/sdk/api/courses/get-lesson.mdx
+++ b/apps/docs/sdk/api/courses/get-lesson.mdx
@@ -7,7 +7,9 @@ description: A course from a courses app experience
 import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.getLesson({
-	// The ID of the experience that has the course.
+	// The ID of the experience that has the course. (this is deprecated, use the
+	// id argument instead. passing this in will return the first course in the
+	// experience for backwards compatibility)
 	experienceId: "exp_XXXXXXXX" /* Required! */,
 
 	lessonId: "xxxxxxxxxxx" /* Required! */,

--- a/apps/docs/sdk/api/courses/get-lesson.mdx
+++ b/apps/docs/sdk/api/courses/get-lesson.mdx
@@ -12,7 +12,7 @@ const result = await whopSdk.courses.getLesson({
 	// experience for backwards compatibility)
 	experienceId: "exp_XXXXXXXX" /* Required! */,
 
-	lessonId: "xxxxxxxxxxx" /* Required! */,
+	lessonId: "lesn_XXXXXXXX" /* Required! */,
 });
 
 ```

--- a/apps/docs/sdk/api/courses/get-user-lesson-interactions.mdx
+++ b/apps/docs/sdk/api/courses/get-user-lesson-interactions.mdx
@@ -8,7 +8,7 @@ import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.getUserLessonInteractions({
 	// The ID of the course to fetch.
-	courseId: "xxxxxxxxxxx" /* Required! */,
+	courseId: "cors_XXXXXXXX" /* Required! */,
 });
 
 ```

--- a/apps/docs/sdk/api/courses/get-user-lesson-interactions.mdx
+++ b/apps/docs/sdk/api/courses/get-user-lesson-interactions.mdx
@@ -7,8 +7,8 @@ description: A course from a courses app experience
 import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.getUserLessonInteractions({
-	// The ID of the experience that has the course.
-	experienceId: "exp_XXXXXXXX" /* Required! */,
+	// The ID of the course to fetch.
+	courseId: "xxxxxxxxxxx" /* Required! */,
 });
 
 ```

--- a/apps/docs/sdk/api/courses/mark-lesson-as-completed.mdx
+++ b/apps/docs/sdk/api/courses/mark-lesson-as-completed.mdx
@@ -7,7 +7,7 @@ import { whopSdk } from "@/lib/whop-sdk";
 
 const result = await whopSdk.courses.markLessonAsCompleted({
 	// The ID of the lesson to mark as completed
-	lessonId: "xxxxxxxxxxx" /* Required! */,
+	lessonId: "lesn_XXXXXXXX" /* Required! */,
 });
 
 ```

--- a/apps/docs/sdk/api/courses/update-chapter-order.mdx
+++ b/apps/docs/sdk/api/courses/update-chapter-order.mdx
@@ -10,7 +10,7 @@ const result = await whopSdk.courses.updateChapterOrder({
 	belowChapterId: "xxxxxxxxxxx",
 
 	// The ID of the chapter to reorder
-	chapterId: "xxxxxxxxxxx" /* Required! */,
+	chapterId: "chap_XXXXXXXX" /* Required! */,
 });
 
 ```

--- a/apps/docs/sdk/api/courses/update-lesson-order.mdx
+++ b/apps/docs/sdk/api/courses/update-lesson-order.mdx
@@ -10,10 +10,10 @@ const result = await whopSdk.courses.updateLessonOrder({
 	belowLessonId: "xxxxxxxxxxx",
 
 	// The ID of the chapter to move the lesson to
-	chapterId: "xxxxxxxxxxx" /* Required! */,
+	chapterId: "chap_XXXXXXXX" /* Required! */,
 
 	// The ID of the lesson to reorder
-	lessonId: "xxxxxxxxxxx" /* Required! */,
+	lessonId: "lesn_XXXXXXXX" /* Required! */,
 });
 
 ```

--- a/packages/api/graphql/operations/courses/get-user-lesson-interactions.shared.graphql
+++ b/packages/api/graphql/operations/courses/get-user-lesson-interactions.shared.graphql
@@ -1,5 +1,5 @@
-query getUserLessonInteractions($experienceId: ID!) {
-	course(experienceId: $experienceId) {
+query getUserLessonInteractions($courseId: ID!) {
+	course(id: $courseId) {
 		chapters {
 			id
 			lessons {

--- a/packages/graphql-codegen-docs/src/input.ts
+++ b/packages/graphql-codegen-docs/src/input.ts
@@ -35,6 +35,10 @@ const idPrefixes = {
 	feedId: "feed",
 	ledgerAccountId: "ldgr",
 	chatExperienceId: "exp",
+	courseId: "cors",
+	lessonId: "lesn",
+	chapterId: "chap",
+	muxAssetId: "mux",
 };
 
 type PrimitiveKind =


### PR DESCRIPTION
since an experience can now have many courses, the `course` field on graphql now accepts an `id`