### PR TITLE
Add visibility field on course lessons

### DIFF
--- a/.changeset/beige-tables-build.md
+++ b/.changeset/beige-tables-build.md
@@ -1,0 +1,5 @@
+---
+"@whop/api": patch
+---
+
+Add visibility field on course lessons

--- a/apps/docs/sdk/api/courses/create-chapter.mdx
+++ b/apps/docs/sdk/api/courses/create-chapter.mdx
@@ -44,6 +44,9 @@ const response = {
 			// The order of the lesson within its chapter
 			order: 10,
 
+			// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+			visibility: "hidden" /* Valid values: hidden | visible */,
+
 			// Number of days from course start until the lesson is unlocked
 			daysFromCourseStartUntilUnlock: 10,
 

--- a/apps/docs/sdk/api/courses/create-lesson.mdx
+++ b/apps/docs/sdk/api/courses/create-lesson.mdx
@@ -42,6 +42,9 @@ const response = {
 	// The order of the lesson within its chapter
 	order: 10,
 
+	// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+	visibility: "hidden" /* Valid values: hidden | visible */,
+
 	// The content of the lesson
 	content: "some string",
 

--- a/apps/docs/sdk/api/courses/get-course.mdx
+++ b/apps/docs/sdk/api/courses/get-course.mdx
@@ -48,6 +48,9 @@ const response = {
 					// The order of the lesson within its chapter
 					order: 10,
 
+					// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+					visibility: "hidden" /* Valid values: hidden | visible */,
+
 					// Number of days from course start until the lesson is unlocked
 					daysFromCourseStartUntilUnlock: 10,
 

--- a/apps/docs/sdk/api/courses/get-lesson.mdx
+++ b/apps/docs/sdk/api/courses/get-lesson.mdx
@@ -34,6 +34,9 @@ const response = {
 		// The order of the lesson within its chapter
 		order: 10,
 
+		// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+		visibility: "hidden" /* Valid values: hidden | visible */,
+
 		// The content of the lesson
 		content: "some string",
 

--- a/apps/docs/sdk/api/courses/list-courses-for-experience.mdx
+++ b/apps/docs/sdk/api/courses/list-courses-for-experience.mdx
@@ -57,6 +57,9 @@ const response = {
 								// The order of the lesson within its chapter
 								order: 10,
 
+								// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+								visibility: "hidden" /* Valid values: hidden | visible */,
+
 								// Number of days from course start until the lesson is unlocked
 								daysFromCourseStartUntilUnlock: 10,
 

--- a/apps/docs/sdk/api/courses/update-chapter-order.mdx
+++ b/apps/docs/sdk/api/courses/update-chapter-order.mdx
@@ -44,6 +44,9 @@ const response = {
 			// The order of the lesson within its chapter
 			order: 10,
 
+			// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+			visibility: "hidden" /* Valid values: hidden | visible */,
+
 			// Number of days from course start until the lesson is unlocked
 			daysFromCourseStartUntilUnlock: 10,
 

--- a/apps/docs/sdk/api/courses/update-chapter.mdx
+++ b/apps/docs/sdk/api/courses/update-chapter.mdx
@@ -44,6 +44,9 @@ const response = {
 			// The order of the lesson within its chapter
 			order: 10,
 
+			// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+			visibility: "hidden" /* Valid values: hidden | visible */,
+
 			// Number of days from course start until the lesson is unlocked
 			daysFromCourseStartUntilUnlock: 10,
 

--- a/apps/docs/sdk/api/courses/update-lesson-order.mdx
+++ b/apps/docs/sdk/api/courses/update-lesson-order.mdx
@@ -35,6 +35,9 @@ const response = {
 	// The order of the lesson within its chapter
 	order: 10,
 
+	// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+	visibility: "hidden" /* Valid values: hidden | visible */,
+
 	// The content of the lesson
 	content: "some string",
 

--- a/apps/docs/sdk/api/courses/update-lesson.mdx
+++ b/apps/docs/sdk/api/courses/update-lesson.mdx
@@ -21,6 +21,9 @@ const result = await whopSdk.courses.updateLesson({
 
 	// The title of the lesson
 	title: "some string",
+
+	// Determines how / whether this lesson is visible to users.
+	visibility: "hidden" /* Valid values: hidden | visible */,
 });
 
 ```
@@ -41,6 +44,9 @@ const response = {
 
 	// The order of the lesson within its chapter
 	order: 10,
+
+	// The visibility of the lesson. Determines how / whether this lesson is visible to users.
+	visibility: "hidden" /* Valid values: hidden | visible */,
 
 	// The content of the lesson
 	content: "some string",

--- a/packages/api/graphql/fragments/basic-course-fragment.graphql
+++ b/packages/api/graphql/fragments/basic-course-fragment.graphql
@@ -28,6 +28,7 @@ fragment BasicCourseLesson on Lesson {
 	lessonType
 	title
 	order
+	visibility
 	daysFromCourseStartUntilUnlock
 	content
 	muxAsset {

--- a/packages/api/graphql/fragments/full-lesson-fragment.graphql
+++ b/packages/api/graphql/fragments/full-lesson-fragment.graphql
@@ -4,6 +4,7 @@ fragment FullCourseLesson on Lesson {
 	lessonType
 	title
 	order
+	visibility
 	content
 	daysFromCourseStartUntilUnlock
 	muxAsset {


### PR DESCRIPTION
Course lessons now have a `visibility` field.

If you are an admin, you will be able to see all lessons in a course.

If you are a normal user (i.e. a student viewing the course), you will only receive the visible lessons from graphql.

closes ENG-13545