### PR TITLE
feat: hide submit button in embedded checkout

### DIFF
--- a/.changeset/eager-planets-beg.md
+++ b/.changeset/eager-planets-beg.md
@@ -1,0 +1,6 @@
+---
+"@whop/checkout": patch
+"@whop/react": patch
+---
+
+feat: hide submit button in embedded checkout

--- a/apps/docs/features/checkout-embed.mdx
+++ b/apps/docs/features/checkout-embed.mdx
@@ -69,6 +69,12 @@ This can be used to attach metadata to a checkout by first creating a session th
 
 Defaults to `false`
 
+#### **`hideTermsAndConditions`**
+
+**Optional** - Set to `true` to hide the terms and conditions in the embedded checkout form.
+
+Defaults to `false`
+
 #### **`skipRedirect`**
 
 **Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
@@ -276,6 +282,16 @@ Defaults to `false`
 
 ```md
 <div data-whop-checkout-hide-submit-button="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
+```
+
+#### **`data-whop-checkout-hide-tos`**
+
+**Optional** - Set to `true` to hide the terms and conditions in the embedded checkout form.
+
+Defaults to `false`
+
+```md
+<div data-whop-checkout-hide-tos="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
 ```
 
 #### **`data-whop-checkout-skip-redirect`**

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -137,6 +137,16 @@ Defaults to `false`
 <div data-whop-checkout-hide-submit-button="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
 ```
 
+### **`data-whop-checkout-hide-tos`**
+
+**Optional** - Set to `true` to hide the terms and conditions in the embedded checkout form.
+
+Defaults to `false`
+
+```md
+<div data-whop-checkout-hide-tos="true" data-whop-checkout-plan-id="plan_XXXXXXXXX"></div>
+```
+
 ### **`data-whop-checkout-skip-redirect`**
 
 **Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.

--- a/packages/checkout/src/index.ts
+++ b/packages/checkout/src/index.ts
@@ -150,6 +150,7 @@ function mount(node: HTMLElement) {
 		getPrefillFromNode(node),
 		getThemeOptionsFromNode(node),
 		node.dataset.whopCheckoutHideSubmitButton === "true",
+		node.dataset.whopCheckoutHideTos === "true",
 	);
 
 	const iframe = document.createElement("iframe");

--- a/packages/checkout/src/util.ts
+++ b/packages/checkout/src/util.ts
@@ -101,6 +101,7 @@ export function getEmbeddedCheckoutIframeUrl(
 	prefill?: WhopEmbeddedCheckoutPrefillOptions,
 	themeOptions?: WhopEmbeddedCheckoutThemeOptions,
 	hideSubmitButton?: boolean,
+	hideTermsAndConditions?: boolean,
 ) {
 	const iframeUrl = new URL(
 		`/embedded/checkout/${planId}/`,
@@ -123,6 +124,9 @@ export function getEmbeddedCheckoutIframeUrl(
 	}
 	if (hideSubmitButton) {
 		iframeUrl.searchParams.set("hide_submit_button", "true");
+	}
+	if (hideTermsAndConditions) {
+		iframeUrl.searchParams.set("hide_tos", "true");
 	}
 	if (utm) {
 		for (const [key, value] of Object.entries(utm).sort((a, b) =>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -158,6 +158,12 @@ export default function Home() {
 			 */
 			hidePrice={false}
 			/**
+			 * **Optional** - Set to `true` to hide the terms and conditions in the embedded checkout form.
+			 *
+			 * @default false
+			 */
+			hideTermsAndConditions={false}
+			/**
 			 * **Optional** - Set to `true` to skip the final redirect and keep the top frame loaded.
 			 *
 			 * @default false

--- a/packages/react/src/checkout/embed.tsx
+++ b/packages/react/src/checkout/embed.tsx
@@ -116,6 +116,12 @@ export interface WhopCheckoutEmbedProps {
 	 * @default false
 	 */
 	hideSubmitButton?: boolean;
+	/**
+	 * **Optional** - Set to `true` to hide the terms and conditions in the embedded checkout form.
+	 *
+	 * @default false
+	 */
+	hideTermsAndConditions?: boolean;
 }
 
 export type {
@@ -137,6 +143,7 @@ function WhopCheckoutEmbedInner({
 	prefill,
 	themeOptions,
 	hideSubmitButton = false,
+	hideTermsAndConditions = false,
 }: WhopCheckoutEmbedProps): ReactNode {
 	const resolvedThemeOptions: WhopEmbeddedCheckoutThemeOptions = useMemo(() => {
 		return {
@@ -158,6 +165,7 @@ function WhopCheckoutEmbedInner({
 		prefill,
 		resolvedThemeOptions,
 		hideSubmitButton,
+		hideTermsAndConditions,
 	);
 
 	const iframeRef = useRef<HTMLIFrameElement>(null);

--- a/packages/react/src/checkout/util.ts
+++ b/packages/react/src/checkout/util.ts
@@ -40,6 +40,7 @@ function useWarnOnIframeUrlChange(
 		prefill,
 		themeOptions,
 		hideSubmitButton,
+		hideTermsAndConditions,
 	]: GetEmbeddedCheckoutIframeUrlParams
 ) {
 	const updatedIframeUrl = useMemo(
@@ -56,6 +57,7 @@ function useWarnOnIframeUrlChange(
 				prefill,
 				themeOptions,
 				hideSubmitButton,
+				hideTermsAndConditions,
 			),
 		[
 			planId,
@@ -68,6 +70,7 @@ function useWarnOnIframeUrlChange(
 			prefill,
 			themeOptions,
 			hideSubmitButton,
+			hideTermsAndConditions,
 		],
 	);
 


### PR DESCRIPTION
Adds support for passing the `hide_tos` parameter to the checkout embed. This is useful when the company global setting to require ToS is enabled and should show on standalone checkouts but the embed should not show it