### PR TITLE
fix: correct embed checkout url in sidebar

### DIFF
--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -116,7 +116,7 @@
 				"payments/create-a-whop",
 				"payments/create-a-product",
 				"payments/create-checkout-link",
-				"payments/embed-checkout",
+				"payments/checkout-embed",
 				"payments/set-up-payouts"
 			]
 		},


### PR DESCRIPTION
Fixed incorrect URL for checkout embed in sidebar. Right now it just 404s and goes to homepage. 